### PR TITLE
Specify non-CRAN rethinking dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,4 +17,6 @@ Imports:
   rethinking (>= 1.59),
   rstan,
   tibble
+Remotes:
+  github::rmcelreath/rethinking
 RoxygenNote: 6.0.1


### PR DESCRIPTION
This ensures the package installs rethinking if the user does not have it. Note this won't work if reskew is on CRAN.